### PR TITLE
[fix] Tools in dev packages 

### DIFF
--- a/packages/base-eth-keyring/package.json
+++ b/packages/base-eth-keyring/package.json
@@ -26,17 +26,17 @@
     "build": "tsdx build"
   },
   "dependencies": {
-    "@babel/preset-typescript": "^7.15.0",
     "@ethereumjs/tx": "3.0.0",
     "@keystonehq/bc-ur-registry-eth": "^0.6.9",
     "ethereumjs-util": "^7.0.8",
     "hdkey": "^2.0.1",
-    "tsdx": "^0.14.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@babel/preset-typescript": "^7.15.0",
     "@types/hdkey": "2.0.0",
-    "@types/uuid": "^8.3.1"
+    "@types/uuid": "^8.3.1",
+    "tsdx": "^0.14.1"
   },
   "bugs": {
     "url": "https://github.com/KeystoneHQ/keystone-airgaped-base/issues"

--- a/packages/eth-keyring/package.json
+++ b/packages/eth-keyring/package.json
@@ -18,7 +18,6 @@
     "author": "soralit <soralitria@gmail.com>",
     "license": "ISC",
     "dependencies": {
-        "@babel/preset-typescript": "^7.15.0",
         "@ethereumjs/tx": "3.0.0",
         "@keystonehq/base-eth-keyring": "^0.0.5",
         "@keystonehq/bc-ur-registry-eth": "^0.6.9",
@@ -30,6 +29,7 @@
         "uuid": "^8.3.2"
     },
     "devDependencies": {
+        "@babel/preset-typescript": "^7.15.0",
         "@types/bs58check": "^2.1.0",
         "@types/hdkey": "2.0.0",
         "@types/uuid": "^8.3.1",

--- a/packages/eth-keyring/package.json
+++ b/packages/eth-keyring/package.json
@@ -27,7 +27,6 @@
         "bs58check": "^2.1.2",
         "ethereumjs-util": "^7.0.8",
         "hdkey": "^2.0.1",
-        "tsdx": "^0.14.1",
         "uuid": "^8.3.2"
     },
     "devDependencies": {

--- a/packages/keystone-connector/package.json
+++ b/packages/keystone-connector/package.json
@@ -29,14 +29,13 @@
   },
   "dependencies": {
     "@0x/subproviders": "^6.5.4",
-    "@babel/preset-typescript": "^7.15.0",
     "@keystonehq/keystone-subprovider": "^0.8.7",
     "@web3-react/abstract-connector": "^6.0.7",
     "@web3-react/types": "^6.0.7",
-    "tsdx": "^0.14.1",
     "web3-provider-engine": "^16.0.3"
   },
   "devDependencies": {
+    "@babel/preset-typescript": "^7.15.0",
     "tsdx": "^0.14.1"
   }
 }

--- a/packages/keystone-subprovider/package.json
+++ b/packages/keystone-subprovider/package.json
@@ -35,16 +35,15 @@
   },
   "dependencies": {
     "@0x/subproviders": "^6.5.4",
-    "@babel/preset-typescript": "^7.15.0",
     "@ethereumjs/common": "2.4.0",
     "@ethereumjs/tx": "3.3.0",
     "@keystonehq/bc-ur-registry-eth": "^0.6.9",
     "@keystonehq/sdk": "^0.7.9",
     "ethereumjs-util": "^7.0.8",
-    "tsdx": "^0.14.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@babel/preset-typescript": "^7.15.0",
     "tsdx": "^0.14.1"
   }
 }

--- a/packages/metamask-airgapped-keyring/package.json
+++ b/packages/metamask-airgapped-keyring/package.json
@@ -26,15 +26,17 @@
     "build": "tsdx build"
   },
   "dependencies": {
-    "@babel/preset-typescript": "^7.15.0",
     "@ethereumjs/tx": "^3.3.0",
     "@keystonehq/base-eth-keyring": "^0.0.5",
     "@keystonehq/bc-ur-registry-eth": "^0.6.9",
     "@metamask/obs-store": "^7.0.0",
     "hdkey": "^2.0.1",
     "rlp": "^2.2.6",
-    "tsdx": "^0.14.1",
     "uuid": "^8.3.2"
+  },
+  "devDependencies": {
+    "@babel/preset-typescript": "^7.15.0",
+    "tsdx": "^0.14.1"
   },
   "bugs": {
     "url": "https://github.com/KeystoneHQ/keystone-airgaped-base/issues"

--- a/packages/qr-protocol/package.json
+++ b/packages/qr-protocol/package.json
@@ -21,10 +21,8 @@
     "dist"
   ],
   "dependencies": {
-    "@babel/preset-typescript": "^7.15.0",
     "@ngraveio/bc-ur": "^1.0.0",
-    "protobufjs": "^6.10.1",
-    "tsdx": "^0.14.1"
+    "protobufjs": "^6.10.1"
   },
   "repository": {
     "type": "git",
@@ -45,6 +43,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@babel/preset-typescript": "^7.15.0"
+    "@babel/preset-typescript": "^7.15.0",
+    "tsdx": "^0.14.1"
   }
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -28,24 +28,23 @@
     "url": "https://github.com/KeystoneHQ/keystone-airgaped-base/issues"
   },
   "dependencies": {
-    "@babel/preset-typescript": "^7.15.0",
     "@ngraveio/bc-ur": "^1.0.0",
-    "@types/qrcode.react": "^1.0.1",
-    "@types/react-dom": "^17.0.9",
-    "@types/react-modal": "^3.12.0",
-    "@types/react-qr-reader": "^2.1.3",
     "qrcode.react": "^1.0.1",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-modal": "^3.12.1",
     "react-qr-reader": "^2.2.1",
-    "rxjs": "^6.6.3",
-    "tsdx": "^0.14.1"
+    "rxjs": "^6.6.3"
   },
   "publishConfig": {
     "access": "public"
   },
   "devDependencies": {
+    "@babel/preset-typescript": "^7.15.0",
+    "@types/qrcode.react": "^1.0.1",
+    "@types/react-dom": "^17.0.9",
+    "@types/react-modal": "^3.12.0",
+    "@types/react-qr-reader": "^2.1.3",
     "html-webpack-plugin": "^5.3.2",
     "tsdx": "^0.14.1",
     "webpack": "^5.48.0",

--- a/packages/ur-registry-eth/package.json
+++ b/packages/ur-registry-eth/package.json
@@ -24,14 +24,13 @@
   "author": "soralit <soralitria@gmail.com>",
   "license": "ISC",
   "dependencies": {
-    "@babel/preset-typescript": "^7.15.0",
-    "@keystonehq/bc-ur-registry": "^0.4.4",
     "ethereumjs-util": "^7.0.8",
     "hdkey": "^2.0.1",
-    "tsdx": "^0.14.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "@babel/preset-typescript": "^7.15.0",
+    "@keystonehq/bc-ur-registry": "^0.4.4",
     "@types/uuid": "^8.3.1",
     "tsdx": "^0.14.1"
   }


### PR DESCRIPTION
### Summary
The `tsdx` tool should be only included in `devDependencies`, if it's declated in 'dependencies` this package is included in the build output.

[`bnc-onboard`](https://github.com/blocknative/onboard/) uses the `@keystonehq/eth-keyring` lib. bnc-onboard is ussually used together with React, causing a version conflict with jest. The reason is React includes `react-scripts` which it includes `jest` version `26.6.0` and `tsdx` uses version `^25.3.0`. causing [this issue](https://github.com/blocknative/onboard/issues/690).

By simplifying moving `tsdx` from `dependencies` to `devDependencies`, the issue is solved. 