### PR TITLE
Bump `@metamask/obs-store`

### DIFF
--- a/packages/eth-keyring/package.json
+++ b/packages/eth-keyring/package.json
@@ -21,7 +21,6 @@
     "@keystonehq/base-eth-keyring": "^0.14.1",
     "@keystonehq/bc-ur-registry-eth": "^0.19.1",
     "@keystonehq/sdk": "^0.19.2",
-    "@metamask/obs-store": "^7.0.0",
     "bs58check": "^2.1.2",
     "ethereumjs-util": "^7.0.8",
     "hdkey": "^2.0.1",

--- a/packages/metamask-airgapped-keyring/package.json
+++ b/packages/metamask-airgapped-keyring/package.json
@@ -29,7 +29,7 @@
     "@ethereumjs/tx": "^4.0.2",
     "@keystonehq/base-eth-keyring": "^0.14.1",
     "@keystonehq/bc-ur-registry-eth": "^0.19.1",
-    "@metamask/obs-store": "^7.0.0",
+    "@metamask/obs-store": "^9.0.0",
     "rlp": "^2.2.6",
     "uuid": "^8.3.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,8 +403,8 @@ importers:
         specifier: ^0.19.1
         version: link:../ur-registry-eth
       '@metamask/obs-store':
-        specifier: ^7.0.0
-        version: 7.0.0
+        specifier: ^9.0.0
+        version: 9.0.0
       rlp:
         specifier: ^2.2.6
         version: 2.2.6
@@ -3374,8 +3374,21 @@ packages:
       through2: 2.0.5
     dev: false
 
+  /@metamask/obs-store@9.0.0:
+    resolution: {integrity: sha512-GDsEh2DTHgmISzJt8erf9T4Ph38iwD2yDJ6J1YFq/IcWRGnT1bkgSEVqZMv9c9JloX02T5bFIUK6+9m9EycI6A==}
+    engines: {node: ^14.21 || ^16.20 || ^18.16 || >=20}
+    dependencies:
+      '@metamask/safe-event-emitter': 3.0.0
+      readable-stream: 3.6.2
+    dev: false
+
   /@metamask/safe-event-emitter@2.0.0:
     resolution: {integrity: sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==}
+    dev: false
+
+  /@metamask/safe-event-emitter@3.0.0:
+    resolution: {integrity: sha512-j6Z47VOmVyGMlnKXZmL0fyvWfEYtKWCA9yGZkU3FCsGZUT5lHGmvaV9JA5F2Y+010y7+ROtR3WMXIkvl/nVzqQ==}
+    engines: {node: '>=12.0.0'}
     dev: false
 
   /@ngraveio/bc-ur@1.1.6:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,9 +263,6 @@ importers:
       '@keystonehq/sdk':
         specifier: ^0.19.2
         version: link:../sdk
-      '@metamask/obs-store':
-        specifier: ^7.0.0
-        version: 7.0.0
       bs58check:
         specifier: ^2.1.2
         version: 2.1.2
@@ -3364,14 +3361,6 @@ packages:
   /@ledgerhq/logs@4.72.0:
     resolution: {integrity: sha512-o+TYF8vBcyySRsb2kqBDv/KMeme8a2nwWoG+lAWzbDmWfb2/MrVWYCVYDYvjXdSoI/Cujqy1i0gIDrkdxa9chA==}
     requiresBuild: true
-    dev: false
-
-  /@metamask/obs-store@7.0.0:
-    resolution: {integrity: sha512-Tr61Uu9CGXkCg5CZwOYRMQERd+y6fbtrtLd/PzDTPHO5UJpmSbU+7MPcQK7d1DwZCOCeCIvhmZSUCvYliC8uGw==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      '@metamask/safe-event-emitter': 2.0.0
-      through2: 2.0.5
     dev: false
 
   /@metamask/obs-store@9.0.0:


### PR DESCRIPTION
- `feat(metamask-airgapped-keyring)`: Update `@metamask/obs-store` from `^7.0.0` to `^9.0.0`
- `fix(eth-keyring)`: Remove unused dependency `@metamask/obs-store`

#### References
- https://github.com/MetaMask/obs-store/releases
- https://github.com/MetaMask/obs-store/compare/v7.0.0...v9.0.0